### PR TITLE
basePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ With `gulp-glob-html` you can use [glob](https://github.com/isaacs/node-glob) fu
 <head lang="en">
     <meta charset="UTF-8">
     <title>glob-html example</title>
-    
+
     <link href="css/*.css" rel="stylesheet" type="text/css">
-    	
+
     <script src="scripts/*"></script>
 </head>
 <body>
@@ -35,11 +35,11 @@ and receive the template with matched css and js entries:
 <head lang="en">
     <meta charset="UTF-8">
     <title>glob-html example</title>
-    
+
     <link href="css/style1.css" rel="stylesheet" type="text/css">
     <link href="css/style2.css" rel="stylesheet" type="text/css">
     <link href="css/style3.css" rel="stylesheet" type="text/css">
-    	
+
     <script src="scripts/script1.js"></script>
     <script src="scripts/script2.js"></script>
     <script src="scripts/script3.js"></script>
@@ -60,6 +60,19 @@ var gulp = require('gulp'),
 gulp.task('default', function () {
     return gulp.src('./templates/**/*.html')
         .pipe(globhtml())
+        .pipe(gulp.dest('./temp'));
+});
+```
+
+Use 'basePath' option to skip url prefix:
+```js
+
+var gulp = require('gulp'),
+    globhtml = require('gulp-glob-html');
+
+gulp.task('default', function () {
+    return gulp.src('./templates/**/*.html')
+        .pipe(globhtml({ basePath: "../dist/" }))
         .pipe(gulp.dest('./temp'));
 });
 ```

--- a/glob-html.js
+++ b/glob-html.js
@@ -12,15 +12,19 @@ var cheerio = require('cheerio'),
  * @param {object} $element Element with glob.
  * @param {string} attr Resource attr. (src, href).
  * @param {string} base Base directory to search in.
+ * @param {object} opts Options
  * @return {Array<object>} matched values.
  * */
-var expandElement = function ($element, attr, base) {
+var expandElement = function ($element, attr, base, opts) {
     var path = $element.attr(attr),
         expandedPaths = glob.sync(path, { cwd : base });
 
     //grunt.log.writeln('Expand ' + path.cyan + ' to ' + expandedPaths.length.toString().cyan + ' files');
 
     return expandedPaths.map(function (path) {
+        if (typeof opts.basePath === 'string' && path.indexOf(opts.basePath) === 0) {
+            path = path.substring(opts.basePath.length);
+        }
         return $element.clone().attr(attr, path).toString();
     });
 };
@@ -64,7 +68,7 @@ var fetchIndent = function ($element) {
     return '\n' + indent;
 };
 
-var processFile = function (content, base) {
+var processFile = function (content, base, opts) {
     var $ = cheerio.load(content),
         $elements = $('script,link'),
         noElementsFound = true;
@@ -80,7 +84,7 @@ var processFile = function (content, base) {
         indent = fetchIndent($element);
 
         // Expand initial script to matched ones.
-        expandElement($element, attr, base).forEach(function (element, i) {
+        expandElement($element, attr, base, opts).forEach(function (element, i) {
             if (i === 0) {
                 $element.before(element);
             } else {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,9 +8,15 @@ gulp.task('globhtml', function () {
         .pipe(gulp.dest('./test/tmp'));
 });
 
-gulp.task('test', function () {
+gulp.task('globhtmlbasepath', function () {
+    return gulp.src('./test/examples/content.html')
+        .pipe(globhtml({ basePath: "scripts1" }))
+        .pipe(gulp.dest('./test/tmp/basePath'));
+});
+
+gulp.task('test', ['globhtml', 'globhtmlbasepath'], function () {
     return gulp.src('./test/*.js')
         .pipe(mocha());
 });
 
-gulp.task('default', ['globhtml', 'test']);
+gulp.task('default', ['test']);

--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@ var through = require('through2'),
     gutil = require('gulp-util'),
     globhtml = require('./glob-html');
 
-module.exports = function () {
+module.exports = function (options) {
     return through.obj(function (file, enc, cb) {
+        var opts = options ? options : {};
         var content;
 
         if (file.isStream()) {
@@ -11,8 +12,8 @@ module.exports = function () {
             return cb();
         }
         if (file.isBuffer()) {
-            content = file.contents.toString('utf8');
-            content = globhtml(content, file.base);
+            content = file.contents.toString(enc);
+            content = globhtml(content, file.base, opts);
             file.contents = new Buffer(content);
         }
         this.push(file);

--- a/test/expected/content_base_path.html
+++ b/test/expected/content_base_path.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title></title>
+
+	<link href="css/style1.css" rel="stylesheet" type="text/css">
+	<link href="css/style2.css" rel="stylesheet" type="text/css">
+	<link href="css/style3.css" rel="stylesheet" type="text/css">
+
+    <script src="/more/another-script.js"></script>
+    <script src="/script1.js"></script>
+    <script src="/script2.js"></script>
+    <script src="/script3.js"></script>
+    <script src="scripts2/script4.js" some-attr="some-value"></script>
+    <script src="scripts2/script5.js" some-attr="some-value"></script>
+    <script src="scripts2/script6.js" some-attr="some-value"></script>
+    <script>
+        console.log("inline script should not be touched");
+    </script>
+</head>
+<body>
+    <span>&quot;</span>
+</body>
+</html>

--- a/test/glob-html.spec.js
+++ b/test/glob-html.spec.js
@@ -14,5 +14,10 @@ describe('glob-html', function(){
             expected = fs.readFileSync('test/examples/empty-content.html').toString();
         assert.equal(actual, expected);
     });
+    it('should expand glob sources with base path', function() {
+        var actual = fs.readFileSync('test/tmp/basePath/content.html').toString(),
+            expected = fs.readFileSync('test/expected/content_base_path.html').toString();
+        assert.equal(actual, expected);
+    });
 });
 


### PR DESCRIPTION
With this option you can skip a prefix in script/style path. For example, you place all files to 'dist' folder and then you want to expand glob in your html files, but don't want to see something like '../dist/' in result file.
